### PR TITLE
Server method

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ server.register(akaya, err => {
 After registering `akaya`, the [hapi request object](hapijs.com/api#request-object) will be decorated with the new method `request.aka()`.
 
 ## API
+`server.aka(id, [params])`
+
+Returns an relative URI to a route
+- `id {string}` - required routes `config.id`.
+- `params`
+  - `query {Object.<?string>}` - Necessary query parameters, which will be stringified.
+  - `params {Object.<?string>}` - Necessary path parameters.
+
 `request.aka(id, [params], [options])`
 
 Returns an URI to a route

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -388,3 +388,27 @@ test('akaya >> strips a trailing question mark if query paramter is undefined', 
     t.end();
   });
 });
+
+test('akaya >> server method for relative URI is accessible', t => {
+  const { server } = setup();
+
+  server.route([{
+    method: 'GET',
+    path: '/',
+    handler: function (request, reply) {
+      reply(request.aka('foo'));
+    }
+  }, {
+    method: 'GET',
+    path: '/foo',
+    config: {
+      id: 'foo',
+      handler: function (request, reply) {
+        reply();
+      }
+    }
+  }]);
+
+  t.equal(server.aka('foo'), '/foo');
+  t.end();
+});


### PR DESCRIPTION
This PR exposes the plugin functionality through the server object, making it possible to generate URIs from outside the request scope. I needed this functionality specifically for tests, but I believe there are other use cases for this.

Wrote an additional test to make sure the method is exposed, but the functionality remains the same, just shifted the relative path part of the code to the server method and called it from the request decorator.

Updated README.md API section with the new method.

Thanks for the great plugin!