### PR TITLE
feat: support passing custom router instance in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,12 +145,12 @@ function serverDecorator (server, id, params = {}, options = {}) {
   params = joi.attempt(params, internals.scheme.params)
   options = joi.attempt(options, internals.scheme.options)
 
-  let route;
+  let route
 
-  if(options.router) {
-    route = options.router.ids.get(id);
+  if (options.router) {
+    route = options.router.ids.get(id)
     assert(route, `There is no route on the router with the defined ID (${id})`, 'notFound')
-  }else {
+  } else {
     route = Object.assign({}, lookupRoute(server, id))
   }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "qs": "^6.9.1"
   },
   "peerDependencies": {
-    "@hapi/hapi": ">=18.4.0"
+    "@hapi/hapi": ">=18.4.0",
+    "@hapi/call": ">=8.x.x"
   },
   "engines": {
     "node": ">=12",

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -20,6 +20,19 @@ const getServer = async () => {
   return server
 }
 
+/**
+ * @function
+ * @public
+ *
+ * Setup and expose a Call router
+ *
+ * @returns {Object} Router
+ */
+const getRouter = async () => {
+  return new call.Router();
+};
+
 module.exports = {
-  getServer
+  getServer,
+  getRouter
 }

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -30,8 +30,8 @@ const getServer = async () => {
  * @returns {Object} Router
  */
 const getRouter = async () => {
-  return new call.Router();
-};
+  return new call.Router()
+}
 
 module.exports = {
   getServer,

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -1,4 +1,5 @@
 const hapi = require('@hapi/hapi')
+const call = require('@hapi/call')
 const plugin = require('../index')
 
 /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -19,30 +19,30 @@ test('get the url of a named route', async (t) => {
   t.is(res.payload, 'http://localhost:1337/foo')
 })
 
-test("get the url of a named route on custom router", async t => {
-  const server = await helpers.getServer();
-  const customRouter = await helpers.getRouter();
+test('get the url of a named route on custom router', async t => {
+  const server = await helpers.getServer()
+  const customRouter = await helpers.getRouter()
 
   customRouter.add({
-    id: "bar",
-    method: "GET",
-    path: "/bar"
-  });
+    id: 'bar',
+    method: 'GET',
+    path: '/bar'
+  })
 
   server.route({
-    method: "GET",
-    path: "/foo",
+    method: 'GET',
+    path: '/foo',
     config: {
-      id: "foo",
-      handler(request) {
-        return request.aka("bar", {}, { router: customRouter });
+      id: 'foo',
+      handler (request) {
+        return request.aka('bar', {}, { router: customRouter })
       }
     }
-  });
+  })
 
-  const res = await server.inject("/foo");
-  t.is(res.payload, "http://localhost:1337/bar");
-});
+  const res = await server.inject('/foo')
+  t.is(res.payload, 'http://localhost:1337/bar')
+})
 
 test('throw if no route matches', async (t) => {
   const server = await helpers.getServer()
@@ -60,22 +60,22 @@ test('throw if no route matches', async (t) => {
   t.is(res.statusMessage, 'Not Found')
 })
 
-test("throw if no route matches on custom router", async t => {
-  const server = await helpers.getServer();
-  const customRouter = await helpers.getRouter();
+test('throw if no route matches on custom router', async t => {
+  const server = await helpers.getServer()
+  const customRouter = await helpers.getRouter()
 
   server.route({
-    method: "GET",
-    path: "/",
-    handler(request) {
-      return request.aka("foo", {}, { router: customRouter });
+    method: 'GET',
+    path: '/',
+    handler (request) {
+      return request.aka('foo', {}, { router: customRouter })
     }
-  });
+  })
 
-  const res = await server.inject("/");
-  t.is(res.statusCode, 404);
-  t.is(res.statusMessage, "Not Found");
-});
+  const res = await server.inject('/')
+  t.is(res.statusCode, 404)
+  t.is(res.statusMessage, 'Not Found')
+})
 
 test('throw if there is a missing parameter', async (t) => {
   const server = await helpers.getServer()

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -19,6 +19,31 @@ test('get the url of a named route', async (t) => {
   t.is(res.payload, 'http://localhost:1337/foo')
 })
 
+test("get the url of a named route on custom router", async t => {
+  const server = await helpers.getServer();
+  const customRouter = await helpers.getRouter();
+
+  customRouter.add({
+    id: "bar",
+    method: "GET",
+    path: "/bar"
+  });
+
+  server.route({
+    method: "GET",
+    path: "/foo",
+    config: {
+      id: "foo",
+      handler(request) {
+        return request.aka("bar", {}, { router: customRouter });
+      }
+    }
+  });
+
+  const res = await server.inject("/foo");
+  t.is(res.payload, "http://localhost:1337/bar");
+});
+
 test('throw if no route matches', async (t) => {
   const server = await helpers.getServer()
 
@@ -34,6 +59,23 @@ test('throw if no route matches', async (t) => {
   t.is(res.statusCode, 404)
   t.is(res.statusMessage, 'Not Found')
 })
+
+test("throw if no route matches on custom router", async t => {
+  const server = await helpers.getServer();
+  const customRouter = await helpers.getRouter();
+
+  server.route({
+    method: "GET",
+    path: "/",
+    handler(request) {
+      return request.aka("foo", {}, { router: customRouter });
+    }
+  });
+
+  const res = await server.inject("/");
+  t.is(res.statusCode, 404);
+  t.is(res.statusMessage, "Not Found");
+});
 
 test('throw if there is a missing parameter', async (t) => {
   const server = await helpers.getServer()


### PR DESCRIPTION
When you have a custom `@hapi/call` instance this lets you pass that as an option & akaya does it’s lookup on that instead of server routes.