### PR TITLE
feat: allow wildcard to be optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ function serverDecorator (server, id, params = {}, options = {}) {
     const stripped = routeSection.replace(internals.regexp.braces, '')
     let parsed
 
-    if (stripped.includes('?')) {
+    if (stripped.includes('?') || stripped.slice(-1) === '*') {
       parsed = parseOptional(params.params, routeSection, stripped)
     } else if (stripped.includes('*') && stripped.slice(-1) !== '*') {
       parsed = parseMulti(params.params, routeSection, stripped)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -150,6 +150,60 @@ test('places wildcard parameter in the url', async (t) => {
   const res = await server.inject('/hello/world')
   t.is(res.payload, 'http://localhost:1337/hello/world')
 })
+test('places wildcard parameter in a url with more segments', async (t) => {
+  const server = await helpers.getServer()
+
+  server.route({
+    method: 'GET',
+    path: '/longer-path/{path*}',
+    config: {
+      id: 'foo',
+      handler (request) {
+        return request.aka('foo', { params: { path: 'hello/world' } })
+      }
+    }
+  })
+
+  const res = await server.inject('/longer-path/hello/world')
+  t.is(res.payload, 'http://localhost:1337/longer-path/hello/world')
+})
+
+test('treats wildcard parameter as optional', async (t) => {
+  const server = await helpers.getServer()
+
+  server.route({
+    method: 'GET',
+    path: '/{path*}',
+    config: {
+      id: 'foo',
+      handler (request) {
+        return request.aka('foo')
+      }
+    }
+  })
+
+  const res = await server.inject('/')
+  t.is(res.payload, 'http://localhost:1337')
+})
+
+
+test('treats wildcard parameter as optional in a url with more segments', async (t) => {
+  const server = await helpers.getServer()
+
+  server.route({
+    method: 'GET',
+    path: '/longer-path/{path*}',
+    config: {
+      id: 'foo',
+      handler (request) {
+        return request.aka('foo')
+      }
+    }
+  })
+
+  const res = await server.inject('/longer-path')
+  t.is(res.payload, 'http://localhost:1337/longer-path')
+})
 
 test('places multiple wildcard parameters', async (t) => {
   const server = await helpers.getServer()


### PR DESCRIPTION
The wildcard in routes such as `/my-route/{wildcardTime*}` or `/{wildcard*}` are actually optional, but are currently parsed as `plain` as they don't have `?` character.

This will fire `parseOptional` if the last character is a `*`.

This syntax is only allowed on the 'last segment' by Call, so I haven't put any checks in if it's the 'last segment' as Call blows up automatically.

Please sanity check just in-case I've misunderstood wildcard.